### PR TITLE
Fixes example.exs

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -20,11 +20,6 @@ defmodule MP3Encoder.Pipeline do
         sample_rate: 48_000
       })
       |> child(:converter, %Converter{
-        input_stream_format: %Membrane.RawAudio{
-          channels: 2,
-          sample_format: :s16le,
-          sample_rate: 48_000
-        },
         output_stream_format: %Membrane.RawAudio{
           channels: 2,
           sample_format: :s32le,

--- a/example.exs
+++ b/example.exs
@@ -41,4 +41,4 @@ end
 {:ok, _pipeline_supervisor, _pid} =
   Membrane.Pipeline.start_link(MP3Encoder.Pipeline, "output.mp3")
 
-# Quit the interactive console with CTRL + C, then listen to your "output.mp3" file
+# After speaking into your mic, quit the interactive console with CTRL + C then listen to your "output.mp3" file


### PR DESCRIPTION
Hi,

I wanted to try the mp3 creation from the mic and I couldn't run the example.exs script because it crashed. So here is my contribution to propose an updated version of this basic mp3 encoding pipeline.

To sum it up : I removed Membrane.Caps.Audio.Raw because it is now called RawAudio and it is part of `membrane_raw_audio_format` (https://hexdocs.pm/membrane_raw_audio_format/readme.html) ; I also used the new Pipeline syntax with the all `child/2` functions ; finally I started the pipeline with `Membrane.Pipeline.start_link/2` 