### PR TITLE
Add rate_control option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is a part of [Membrane Multimedia Framework](https://membraneframework.org).
 Add the following line to your `deps` in `mix.exs`. Then, run `mix deps.get`.
 
 ```elixir
-    {:membrane_mp3_lame_plugin, "~> 0.18.5"}
+    {:membrane_mp3_lame_plugin, "~> 0.18.6"}
 ```
 
 This package depends on the [Lame encoder library](http://lame.sourceforge.net) library. The precompiled builds will be pulled and linked automatically. However, should there be any problems, consider installing it manually.

--- a/c_src/membrane_mp3_lame_plugin/encoder.c
+++ b/c_src/membrane_mp3_lame_plugin/encoder.c
@@ -21,7 +21,8 @@ void handle_destroy_state(UnifexEnv *env, State *state) {
   }
 }
 
-UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality, int disable_reservoir, int cbr) {
+UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality,
+                   int disable_reservoir, rate_control rate_control) {
   UNIFEX_TERM result;
   State *state = unifex_alloc_state(env);
   state->lame_state = NULL;
@@ -40,8 +41,24 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality, int d
   lame_set_brate(lame_state, bitrate);
   lame_set_quality(lame_state, quality);
 
-  if (cbr) {
-    lame_set_VBR(lame_state, vbr_off);
+  lame_set_VBR(lame_state, (vbr_mode)rate_control.type);
+
+  if (rate_control.type != vbr_off) {
+    if (rate_control.quality != -1) {
+      lame_set_VBR_q(lame_state, rate_control.quality);
+    }
+    if (rate_control.mean_bitrate != -1) {
+      lame_set_VBR_mean_bitrate_kbps(lame_state, rate_control.mean_bitrate);
+    }
+    if (rate_control.min_bitrate != -1) {
+      lame_set_VBR_min_bitrate_kbps(lame_state, rate_control.min_bitrate);
+    }
+    if (rate_control.max_bitrate != -1) {
+      lame_set_VBR_max_bitrate_kbps(lame_state, rate_control.max_bitrate);
+    }
+    if (rate_control.hard_min) {
+      lame_set_VBR_hard_min(lame_state, 1);
+    }
   }
 
   if (disable_reservoir) {
@@ -125,7 +142,7 @@ UNIFEX_TERM flush(UnifexEnv *env, int is_gapless, State *state) {
   }
   UnifexPayload *output_payload = (UnifexPayload *)unifex_alloc(sizeof(UnifexPayload));
   unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, output_size, output_payload);
-  
+
   memcpy(output_payload->data, state->mp3_buffer, output_size);
 
   UNIFEX_TERM res_term = flush_result_ok(env, output_payload);

--- a/c_src/membrane_mp3_lame_plugin/encoder.c
+++ b/c_src/membrane_mp3_lame_plugin/encoder.c
@@ -44,8 +44,8 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality,
   lame_set_VBR(lame_state, (vbr_mode)rate_control.type);
 
   if (rate_control.type != vbr_off) {
-    if (rate_control.quality != -1) {
-      lame_set_VBR_q(lame_state, rate_control.quality);
+    if (rate_control.quality >= 0) {
+      lame_set_VBR_quality(lame_state, (float)rate_control.quality);
     }
     if (rate_control.mean_bitrate != -1) {
       lame_set_VBR_mean_bitrate_kbps(lame_state, rate_control.mean_bitrate);

--- a/c_src/membrane_mp3_lame_plugin/encoder.c
+++ b/c_src/membrane_mp3_lame_plugin/encoder.c
@@ -21,7 +21,7 @@ void handle_destroy_state(UnifexEnv *env, State *state) {
   }
 }
 
-UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality,
+UNIFEX_TERM create(UnifexEnv *env, int channels, int quality,
                    int disable_reservoir, rate_control rate_control) {
   UNIFEX_TERM result;
   State *state = unifex_alloc_state(env);
@@ -38,12 +38,15 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int bitrate, int quality,
 
   lame_set_num_channels(lame_state, channels);
   lame_set_in_samplerate(lame_state, 44100);
-  lame_set_brate(lame_state, bitrate);
   lame_set_quality(lame_state, quality);
 
   lame_set_VBR(lame_state, (vbr_mode)rate_control.type);
 
-  if (rate_control.type != vbr_off) {
+  if (rate_control.type == vbr_off) {
+    if (rate_control.bitrate != -1) {
+      lame_set_brate(lame_state, rate_control.bitrate);
+    }
+  } else {
     if (rate_control.quality >= 0) {
       lame_set_VBR_quality(lame_state, (float)rate_control.quality);
     }

--- a/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
+++ b/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
@@ -1,6 +1,21 @@
 module Membrane.MP3.Lame.Encoder.Native
 
-spec create(channels :: int, bitrate :: int, quality :: int, disable_reservoir :: bool, cbr :: bool) ::
+type rate_control :: %Membrane.MP3.Lame.Encoder.RateControl{
+       type: int,
+       quality: int,
+       mean_bitrate: int,
+       min_bitrate: int,
+       max_bitrate: int,
+       hard_min: bool
+     }
+
+spec create(
+       channels :: int,
+       bitrate :: int,
+       quality :: int,
+       disable_reservoir :: bool,
+       rate_control :: rate_control
+     ) ::
        {:ok :: label, state} | {:error :: label, reason :: atom}
 
 spec encode_frame(buffer :: payload, state) ::

--- a/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
+++ b/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
@@ -2,6 +2,7 @@ module Membrane.MP3.Lame.Encoder.Native
 
 type rate_control :: %Membrane.MP3.Lame.Encoder.RateControl{
        type: int,
+       bitrate: int,
        quality: float,
        mean_bitrate: int,
        min_bitrate: int,
@@ -11,7 +12,6 @@ type rate_control :: %Membrane.MP3.Lame.Encoder.RateControl{
 
 spec create(
        channels :: int,
-       bitrate :: int,
        quality :: int,
        disable_reservoir :: bool,
        rate_control :: rate_control

--- a/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
+++ b/c_src/membrane_mp3_lame_plugin/encoder.spec.exs
@@ -2,7 +2,7 @@ module Membrane.MP3.Lame.Encoder.Native
 
 type rate_control :: %Membrane.MP3.Lame.Encoder.RateControl{
        type: int,
-       quality: int,
+       quality: float,
        mean_bitrate: int,
        min_bitrate: int,
        max_bitrate: int,

--- a/lib/membrane_mp3_lame/encoder.ex
+++ b/lib/membrane_mp3_lame/encoder.ex
@@ -6,7 +6,7 @@ defmodule Membrane.MP3.Lame.Encoder do
 
   require Membrane.Logger
 
-  alias __MODULE__.Native
+  alias __MODULE__.{Native, RateControl}
   alias Membrane.Buffer
   alias Membrane.MPEGAudio
   alias Membrane.RawAudio
@@ -14,6 +14,32 @@ defmodule Membrane.MP3.Lame.Encoder do
   @samples_per_frame 1152
   @channels 2
   @sample_size 4
+
+  @typedoc """
+  VBR configuration for the `rate_control` option.
+
+  Available options:
+  * `:mode` (required) - Sets the algorithm via `lame_set_VBR/2`.
+  * `:mean_bitrate` (required for `:abr`, not allowed otherwise) -
+    target average bitrate in kbps. Calls  `lame_set_VBR_mean_bitrate_kbps/2`.
+  * `:quality` (only for `:rh`, `:mt`, `:mtrh`, `:default`) -
+    VBR quality level 0..9 (0 = best, 9 = worst). Calls
+    `lame_set_VBR_q/2`. If omitted, LAME's default is used.
+  * `:min_bitrate` - minimum allowed bitrate in kbps. See
+    `lame_set_VBR_min_bitrate_kbps` for reference.
+  * `:max_bitrate` - maximum allowed bitrate in kbps. Calls
+    `lame_set_VBR_max_bitrate_kbps/2`.
+  * `:hard_min` (boolean) - strictly enforce `:min_bitrate` even
+    for silence. Calls `lame_set_VBR_hard_min/2`.
+  """
+  @type vbr_config :: [
+          mode: :mt | :rh | :abr | :mtrh | :default,
+          mean_bitrate: pos_integer(),
+          quality: 0..9,
+          min_bitrate: pos_integer(),
+          max_bitrate: pos_integer(),
+          hard_min: boolean()
+        ]
 
   def_output_pad :output,
     accepted_format: %MPEGAudio{channels: 2, sample_rate: 44_100, layer: :layer3, version: :v1}
@@ -66,13 +92,14 @@ defmodule Membrane.MP3.Lame.Encoder do
                 sources is concatenated.
                 """
               ],
-              cbr: [
-                spec: boolean(),
-                default: false,
+              rate_control: [
+                spec: :cbr | {:vbr, vbr_config()},
+                default: :cbr,
                 description: """
-                When set to true, explicitly enforces constant bitrate (CBR) mode.
-                CBR is already the LAME default when a bitrate is set, but this
-                option makes it explicit via `lame_set_VBR(vbr_off)`.
+                Rate control mode for the encoder:
+                  * `:cbr` - Constant Bitrate. The output bitrate is fixed at the value
+                    of the `bitrate` option.
+                  * `{:vbr, config}` - Variable Bitrate. See `t:vbr_config/0` for details.
                 """
               ]
 
@@ -91,6 +118,7 @@ defmodule Membrane.MP3.Lame.Encoder do
   @impl true
   def handle_setup(_ctx, state) do
     quality_val = state.options.quality |> map_quality_to_value!
+    rate_control = RateControl.parse!(state.options.rate_control)
 
     with {:ok, native} <-
            Native.create(
@@ -98,7 +126,7 @@ defmodule Membrane.MP3.Lame.Encoder do
              state.options.bitrate,
              quality_val,
              state.options.disable_reservoir,
-             state.options.cbr
+             rate_control
            ) do
       {[], %{state | native: native}}
     else

--- a/lib/membrane_mp3_lame/encoder.ex
+++ b/lib/membrane_mp3_lame/encoder.ex
@@ -65,10 +65,13 @@ defmodule Membrane.MP3.Lame.Encoder do
                 """
               ],
               bitrate: [
-                spec: integer(),
-                default: 192,
+                spec: pos_integer() | nil,
+                default: nil,
                 description: """
-                Output bitrate of encoded stream in kbit/sec.
+                Deprecated: pass the bitrate via the `rate_control` option instead,
+                e.g. `rate_control: {:cbr, bitrate: 192}`.
+
+                Output bitrate of encoded stream in kbit/sec, defaults to 192.
                 """
               ],
               quality: [
@@ -97,12 +100,12 @@ defmodule Membrane.MP3.Lame.Encoder do
                 """
               ],
               rate_control: [
-                spec: :cbr | {:vbr, vbr_config()},
+                spec: :cbr | {:cbr, bitrate: pos_integer()} | {:vbr, vbr_config()},
                 default: :cbr,
                 description: """
                 Rate control mode for the encoder:
-                  * `:cbr` - Constant Bitrate. The output bitrate is fixed at the value
-                    of the `bitrate` option.
+                  * `:cbr` - Constant Bitrate at the default bitrate (192 kbps).
+                  * `{:cbr, bitrate: kbps}` - Constant Bitrate at the given bitrate.
                   * `{:vbr, config}` - Variable Bitrate. See `t:vbr_config/0` for details.
                 """
               ]
@@ -122,12 +125,15 @@ defmodule Membrane.MP3.Lame.Encoder do
   @impl true
   def handle_setup(_ctx, state) do
     quality_val = state.options.quality |> map_quality_to_value!
-    rate_control = RateControl.parse!(state.options.rate_control)
+
+    rate_control =
+      state.options.rate_control
+      |> apply_legacy_bitrate(state.options.bitrate)
+      |> RateControl.parse!()
 
     with {:ok, native} <-
            Native.create(
              @channels,
-             state.options.bitrate,
              quality_val,
              state.options.disable_reservoir,
              rate_control
@@ -137,6 +143,17 @@ defmodule Membrane.MP3.Lame.Encoder do
       {:error, reason} ->
         raise "Error initializing mpeg: #{inspect(reason)}"
     end
+  end
+
+  defp apply_legacy_bitrate(rate_control, nil), do: rate_control
+
+  defp apply_legacy_bitrate(rate_control, legacy_bitrate) do
+    Membrane.Logger.warning("""
+    The `bitrate` option is deprecated. Pass the bitrate via `rate_control: \
+    {:cbr, bitrate: #{legacy_bitrate}}` instead.
+    """)
+
+    if rate_control == :cbr, do: {:cbr, bitrate: legacy_bitrate}, else: rate_control
   end
 
   @impl true

--- a/lib/membrane_mp3_lame/encoder.ex
+++ b/lib/membrane_mp3_lame/encoder.ex
@@ -18,19 +18,22 @@ defmodule Membrane.MP3.Lame.Encoder do
   @typedoc """
   VBR configuration for the `rate_control` option.
 
+  For details, see Lame's header file:
+  https://sourceforge.net/p/lame/svn/HEAD/tree/trunk/lame/include/lame.h
+
   Available options:
-  * `:mode` (required) - Sets the algorithm via `lame_set_VBR/2`.
+  * `:mode` (required) - Sets the algorithm via `lame_set_VBR`.
   * `:mean_bitrate` (required for `:abr`, not allowed otherwise) -
-    target average bitrate in kbps. Calls  `lame_set_VBR_mean_bitrate_kbps/2`.
+    target average bitrate in kbps. Calls  `lame_set_VBR_mean_bitrate_kbps`.
   * `:quality` (only for `:rh`, `:mt`, `:mtrh`, `:default`) -
     VBR quality level 0..9 (0 = best, 9 = worst). Calls
-    `lame_set_VBR_q/2`. If omitted, LAME's default is used.
+    `lame_set_VBR_q`. If omitted, LAME's default is used.
   * `:min_bitrate` - minimum allowed bitrate in kbps. See
     `lame_set_VBR_min_bitrate_kbps` for reference.
   * `:max_bitrate` - maximum allowed bitrate in kbps. Calls
-    `lame_set_VBR_max_bitrate_kbps/2`.
+    `lame_set_VBR_max_bitrate_kbps`.
   * `:hard_min` (boolean) - strictly enforce `:min_bitrate` even
-    for silence. Calls `lame_set_VBR_hard_min/2`.
+    for silence. Calls `lame_set_VBR_hard_min`.
   """
   @type vbr_config :: [
           mode: :mt | :rh | :abr | :mtrh | :default,

--- a/lib/membrane_mp3_lame/encoder.ex
+++ b/lib/membrane_mp3_lame/encoder.ex
@@ -26,8 +26,9 @@ defmodule Membrane.MP3.Lame.Encoder do
   * `:mean_bitrate` (required for `:abr`, not allowed otherwise) -
     target average bitrate in kbps. Calls  `lame_set_VBR_mean_bitrate_kbps`.
   * `:quality` (only for `:rh`, `:mt`, `:mtrh`, `:default`) -
-    VBR quality level 0..9 (0 = best, 9 = worst). Calls
-    `lame_set_VBR_q`. If omitted, LAME's default is used.
+    VBR quality level as a number in `[0, 10)` (0 = best, 9 = worst).
+    Calls `lame_set_VBR_quality`, which accepts fractional values
+    for finer-grained control. If omitted, LAME's default is used.
   * `:min_bitrate` - minimum allowed bitrate in kbps. See
     `lame_set_VBR_min_bitrate_kbps` for reference.
   * `:max_bitrate` - maximum allowed bitrate in kbps. Calls
@@ -38,7 +39,7 @@ defmodule Membrane.MP3.Lame.Encoder do
   @type vbr_config :: [
           mode: :mt | :rh | :abr | :mtrh | :default,
           mean_bitrate: pos_integer(),
-          quality: 0..9,
+          quality: number(),
           min_bitrate: pos_integer(),
           max_bitrate: pos_integer(),
           hard_min: boolean()

--- a/lib/membrane_mp3_lame/encoder/rate_control.ex
+++ b/lib/membrane_mp3_lame/encoder/rate_control.ex
@@ -1,0 +1,93 @@
+defmodule Membrane.MP3.Lame.Encoder.RateControl do
+  @moduledoc false
+
+  @vbr_off 0
+  @vbr_mode_to_int %{mt: 1, rh: 2, abr: 3, mtrh: 4, default: 4}
+  @valid_vbr_modes Map.keys(@vbr_mode_to_int)
+
+  @enforce_keys [:type, :quality, :mean_bitrate, :min_bitrate, :max_bitrate, :hard_min]
+  defstruct @enforce_keys
+
+  @spec parse!(:cbr | {:vbr, Keyword.t()}) :: %__MODULE__{}
+  def parse!(:cbr) do
+    %__MODULE__{
+      type: @vbr_off,
+      quality: -1,
+      mean_bitrate: -1,
+      min_bitrate: -1,
+      max_bitrate: -1,
+      hard_min: false
+    }
+  end
+
+  def parse!({:vbr, config}) when is_list(config) do
+    unless Keyword.keyword?(config) do
+      raise ArgumentError, "VBR config must be a keyword list, got: #{inspect(config)}"
+    end
+
+    config =
+      config
+      |> Keyword.validate!(
+        mode: nil,
+        quality: nil,
+        mean_bitrate: nil,
+        min_bitrate: nil,
+        max_bitrate: nil,
+        hard_min: false
+      )
+      |> Map.new()
+
+    validate_config_fields!(config)
+
+    %__MODULE__{
+      type: Map.fetch!(@vbr_mode_to_int, config.mode),
+      quality: config.quality || -1,
+      mean_bitrate: config.mean_bitrate || -1,
+      min_bitrate: config.min_bitrate || -1,
+      max_bitrate: config.max_bitrate || -1,
+      hard_min: config.hard_min
+    }
+  end
+
+  def parse!(value) do
+    raise ArgumentError,
+          "Invalid rate_control: expected :cbr or {:vbr, keyword()}, got: #{inspect(value)}"
+  end
+
+  # LLM-generated validation
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defp validate_config_fields!(config) do
+    unless config.mode in @valid_vbr_modes do
+      raise ArgumentError,
+            "VBR :mode must be one of #{inspect(@valid_vbr_modes)}, got: #{inspect(config.mode)}"
+    end
+
+    if config.mode == :abr and config.mean_bitrate == nil do
+      raise ArgumentError, ":mean_bitrate is required for :abr VBR mode"
+    end
+
+    if config.mode != :abr and config.mean_bitrate != nil do
+      raise ArgumentError,
+            ":mean_bitrate is only valid for :abr VBR mode, got mode: #{inspect(config.mode)}"
+    end
+
+    if config.mode == :abr and not is_nil(config.quality) do
+      raise ArgumentError, ":quality is not applicable for :abr VBR mode"
+    end
+
+    unless config.quality == nil or config.quality in 0..9 do
+      raise ArgumentError, "VBR :quality must be in 0..9, got: #{inspect(config.quality)}"
+    end
+
+    for {key, value} <- Map.take(config, [:mean_bitrate, :min_bitrate, :max_bitrate]),
+        value,
+        not (is_integer(value) and value > 0) do
+      raise ArgumentError,
+            "VBR #{inspect(key)} must be a positive integer (kbps), got: #{inspect(value)}"
+    end
+
+    unless is_boolean(config.hard_min) do
+      raise ArgumentError, "VBR :hard_min must be a boolean, got: #{inspect(config.hard_min)}"
+    end
+  end
+end

--- a/lib/membrane_mp3_lame/encoder/rate_control.ex
+++ b/lib/membrane_mp3_lame/encoder/rate_control.ex
@@ -12,7 +12,7 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
   def parse!(:cbr) do
     %__MODULE__{
       type: @vbr_off,
-      quality: -1,
+      quality: -1.0,
       mean_bitrate: -1,
       min_bitrate: -1,
       max_bitrate: -1,
@@ -41,7 +41,7 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
 
     %__MODULE__{
       type: Map.fetch!(@vbr_mode_to_int, config.mode),
-      quality: config.quality || -1,
+      quality: (config.quality || -1) * 1.0,
       mean_bitrate: config.mean_bitrate || -1,
       min_bitrate: config.min_bitrate || -1,
       max_bitrate: config.max_bitrate || -1,
@@ -75,8 +75,9 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
       raise ArgumentError, ":quality is not applicable for :abr VBR mode"
     end
 
-    unless config.quality == nil or config.quality in 0..9 do
-      raise ArgumentError, "VBR :quality must be in 0..9, got: #{inspect(config.quality)}"
+    unless config.quality == nil or (config.quality >= 0 and config.quality < 10) do
+      raise ArgumentError,
+            "VBR :quality must be a number in [0, 10) range, got: #{inspect(config.quality)}"
     end
 
     for {key, value} <- Map.take(config, [:mean_bitrate, :min_bitrate, :max_bitrate]),

--- a/lib/membrane_mp3_lame/encoder/rate_control.ex
+++ b/lib/membrane_mp3_lame/encoder/rate_control.ex
@@ -5,13 +5,36 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
   @vbr_mode_to_int %{mt: 1, rh: 2, abr: 3, mtrh: 4, default: 4}
   @valid_vbr_modes Map.keys(@vbr_mode_to_int)
 
-  @enforce_keys [:type, :quality, :mean_bitrate, :min_bitrate, :max_bitrate, :hard_min]
+  @enforce_keys [
+    :type,
+    :bitrate,
+    :quality,
+    :mean_bitrate,
+    :min_bitrate,
+    :max_bitrate,
+    :hard_min
+  ]
   defstruct @enforce_keys
 
-  @spec parse!(:cbr | {:vbr, Keyword.t()}) :: %__MODULE__{}
-  def parse!(:cbr) do
+  @spec parse!(:cbr | {:cbr | :vbr, Keyword.t()}) :: %__MODULE__{}
+  def parse!(:cbr), do: parse!({:cbr, []})
+
+  def parse!({:cbr, config}) when is_list(config) do
+    unless Keyword.keyword?(config) do
+      raise ArgumentError, "CBR config must be a keyword list, got: #{inspect(config)}"
+    end
+
+    config = Keyword.validate!(config, bitrate: 192)
+    bitrate = Keyword.fetch!(config, :bitrate)
+
+    unless is_integer(bitrate) and bitrate > 0 do
+      raise ArgumentError,
+            "CBR :bitrate must be a positive integer (kbps), got: #{inspect(bitrate)}"
+    end
+
     %__MODULE__{
       type: @vbr_off,
+      bitrate: bitrate,
       quality: -1.0,
       mean_bitrate: -1,
       min_bitrate: -1,
@@ -41,6 +64,7 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
 
     %__MODULE__{
       type: Map.fetch!(@vbr_mode_to_int, config.mode),
+      bitrate: -1,
       quality: (config.quality || -1) * 1.0,
       mean_bitrate: config.mean_bitrate || -1,
       min_bitrate: config.min_bitrate || -1,
@@ -50,8 +74,7 @@ defmodule Membrane.MP3.Lame.Encoder.RateControl do
   end
 
   def parse!(value) do
-    raise ArgumentError,
-          "Invalid rate_control: expected :cbr or {:vbr, keyword()}, got: #{inspect(value)}"
+    raise ArgumentError, "Invalid rate_control: #{inspect(value)}"
   end
 
   # LLM-generated validation

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.MP3.Lame.Mixfile do
   use Mix.Project
 
-  @version "0.18.5"
+  @version "0.18.6"
   @github_url "https://github.com/membraneframework/membrane_mp3_lame_plugin"
 
   def project do

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -192,6 +192,24 @@ defmodule Membrane.MP3.Lame.Encoder.IntegrationTest do
              "Expected constant frame size (±1 byte padding), got range #{min_size}..#{max_size}: #{inspect(Enum.frequencies(main_sizes))}"
     end
 
+    test "{:cbr, bitrate: N} scales frame size with the requested bitrate" do
+      low_avg = run_encoder({:cbr, bitrate: 64}) |> avg_frame_size()
+      high_avg = run_encoder({:cbr, bitrate: 192}) |> avg_frame_size()
+
+      assert high_avg > low_avg * 2,
+             "Expected higher CBR bitrate to yield larger frames, got #{low_avg} vs #{high_avg}"
+    end
+
+    test "{:cbr, bitrate: N} validates that bitrate is a positive integer" do
+      assert_raise ArgumentError, ~r/CBR :bitrate must be a positive integer/, fn ->
+        Membrane.MP3.Lame.Encoder.RateControl.parse!({:cbr, bitrate: 0})
+      end
+
+      assert_raise ArgumentError, ~r/CBR :bitrate must be a positive integer/, fn ->
+        Membrane.MP3.Lame.Encoder.RateControl.parse!({:cbr, bitrate: -1})
+      end
+    end
+
     test "{:vbr, mode: :mtrh} produces varying frame sizes" do
       frame_sizes = run_encoder({:vbr, mode: :mtrh, quality: 4.5}) |> Enum.map(&byte_size/1)
 

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -210,9 +210,9 @@ defmodule Membrane.MP3.Lame.Encoder.IntegrationTest do
       # average, verify that doubling the target meaningfully increases the
       # average frame size.
       low_avg = run_encoder({:vbr, mode: :abr, mean_bitrate: 64}) |> avg_frame_size()
-      high_avg = run_encoder({:vbr, mode: :abr, mean_bitrate: 256}) |> avg_frame_size()
+      high_avg = run_encoder({:vbr, mode: :abr, mean_bitrate: 128}) |> avg_frame_size()
 
-      assert high_avg > low_avg * 1.3,
+      assert high_avg > low_avg * 1.5,
              "Expected higher :mean_bitrate to yield larger average frames, got #{low_avg} vs #{high_avg}"
     end
 

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -193,7 +193,7 @@ defmodule Membrane.MP3.Lame.Encoder.IntegrationTest do
     end
 
     test "{:vbr, mode: :mtrh} produces varying frame sizes" do
-      frame_sizes = run_encoder({:vbr, mode: :mtrh, quality: 4}) |> Enum.map(&byte_size/1)
+      frame_sizes = run_encoder({:vbr, mode: :mtrh, quality: 4.5}) |> Enum.map(&byte_size/1)
 
       assert length(frame_sizes) > 1, "Expected multiple MP3 frames, got #{length(frame_sizes)}"
 

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -150,8 +150,10 @@ defmodule Membrane.MP3.Lame.Encoder.IntegrationTest do
     end
   end
 
-  describe "cbr option" do
-    test "produces constant-size frame buffers" do
+  describe "rate_control option" do
+    defp run_encoder(rate_control, opts \\ []) do
+      disable_reservoir = Keyword.get(opts, :disable_reservoir, false)
+
       pid =
         Pipeline.start_link_supervised!(
           spec:
@@ -164,23 +166,60 @@ defmodule Membrane.MP3.Lame.Encoder.IntegrationTest do
               },
               overwrite_pts?: true
             })
-            |> child(:encoder, %Membrane.MP3.Lame.Encoder{cbr: true, disable_reservoir: true})
+            |> child(:encoder, %Membrane.MP3.Lame.Encoder{
+              rate_control: rate_control,
+              disable_reservoir: disable_reservoir
+            })
             |> child(:sink, Membrane.Testing.Sink)
         )
 
-      # Collect frame sizes from sink buffers
-      frame_sizes = collect_frames(pid, []) |> Enum.map(&byte_size/1)
+      frames = collect_frames(pid, [])
+      Pipeline.terminate(pid)
+      frames
+    end
+
+    test ":cbr produces constant-size frame buffers" do
+      frame_sizes = run_encoder(:cbr, disable_reservoir: true) |> Enum.map(&byte_size/1)
 
       assert length(frame_sizes) > 1, "Expected multiple MP3 frames, got #{length(frame_sizes)}"
 
       # CBR frames should be constant size, with at most 1-byte variation
-      # from the MP3 padding bit (used to maintain exact average bitrate).
-      # Allow the last frame to differ (flush frame may be shorter).
+      # from the MP3 padding bit. Allow the last (flush) frame to differ.
       main_sizes = Enum.drop(frame_sizes, -1)
       {min_size, max_size} = Enum.min_max(main_sizes)
 
       assert max_size - min_size <= 1,
              "Expected constant frame size (±1 byte padding), got range #{min_size}..#{max_size}: #{inspect(Enum.frequencies(main_sizes))}"
+    end
+
+    test "{:vbr, mode: :mtrh} produces varying frame sizes" do
+      frame_sizes = run_encoder({:vbr, mode: :mtrh, quality: 4}) |> Enum.map(&byte_size/1)
+
+      assert length(frame_sizes) > 1, "Expected multiple MP3 frames, got #{length(frame_sizes)}"
+
+      main_sizes = Enum.drop(frame_sizes, -1)
+      {min_size, max_size} = Enum.min_max(main_sizes)
+
+      assert max_size - min_size > 1,
+             "Expected varying VBR frame sizes, got range #{min_size}..#{max_size}"
+    end
+
+    test "{:vbr, mode: :abr, mean_bitrate: _} scales average frame size with target" do
+      # ABR is a soft target — for highly compressible audio LAME produces
+      # frames well below the requested mean. Instead of asserting a precise
+      # average, verify that doubling the target meaningfully increases the
+      # average frame size.
+      low_avg = run_encoder({:vbr, mode: :abr, mean_bitrate: 64}) |> avg_frame_size()
+      high_avg = run_encoder({:vbr, mode: :abr, mean_bitrate: 256}) |> avg_frame_size()
+
+      assert high_avg > low_avg * 1.3,
+             "Expected higher :mean_bitrate to yield larger average frames, got #{low_avg} vs #{high_avg}"
+    end
+
+    defp avg_frame_size(frames) do
+      # Drop the last frame as it may be shorter
+      main = Enum.drop(frames, -1)
+      Enum.sum(Enum.map(main, &byte_size/1)) / length(main)
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
- Changes `cbr` option (never released) to `rate_control: :cbr | {:cbr | :vbr, config}`
- Deprecates `bitrate` option in favour of `rate_control: {:cbr, bitrate: bitrate}`